### PR TITLE
#64: [server] move issue template logic to nemobot (closes #64)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import Rx from 'rx';
 import { find } from 'lodash';
 import processors from './processors';
+import getTemplates from './templates';
 import { isEvent } from './validators';
 import config from './config';
 
@@ -29,6 +30,10 @@ app.post('/', ({ body, headers }, res) => {
   } else {
     res.status(403).send('Forbidden');
   }
+});
+
+app.get('/templates', ({ query }, res) => {
+  res.send(getTemplates(query));
 });
 
 app.listen(3000);

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import querystring from 'querystring';
+import { prettifierLog } from '../utils';
+import { omit, omitBy } from 'lodash';
+
+const bugTemplate = fs.readFileSync('./templates/bug.md').toString();
+const featureTemplate = fs.readFileSync('./templates/feature.md').toString();
+const defectTemplate = fs.readFileSync('./templates/defect.md').toString();
+const subIssueTemplate = fs.readFileSync('./templates/sub-issue.md').toString();
+
+const title = '[{topic}] {title}';
+
+
+function addComputedQuery(templateObj) {
+  const { labels = [], ..._others} = templateObj;
+  const others = omitBy(_others, x => !x);
+
+  return {
+    ...templateObj,
+    computedQuery: `${querystring.stringify(others)}${[].concat(labels).map(l => `&labels[]=${l}`).join('')}}`
+  };
+}
+
+function replaceVariablesInBody(body, query) {
+  const variableKeys = Object.keys(omit(query, ['t', 'milestone', 'labels', 'assignee', 'topic']));
+  return [body, ...variableKeys].reduce((body, k) => body.replace(RegExp(`\\$${k}`, 'g'), query[k]));
+}
+
+const getGithubQuery = ({ milestone, labels, assignee }) => ({ milestone, labels, assignee });
+
+function getStandard(query) {
+  return {
+    ...getGithubQuery(query),
+    title,
+    titleSelection: '{topic}'
+  };
+}
+
+function getBug({ labels = [], ...query }) {
+  return {
+    ...getGithubQuery(query),
+    title,
+    titleSelection: '{topic}',
+    labels: ['bug', ...labels],
+    body: replaceVariablesInBody(bugTemplate, query)
+  };
+}
+
+function getFeature(query) {
+  return {
+    ...getGithubQuery(query),
+    title,
+    titleSelection: '{topic}',
+    body: replaceVariablesInBody(featureTemplate, query)
+  };
+}
+
+function getDefect({ labels = [], ...query }) {
+  return {
+    ...getGithubQuery(query),
+    title,
+    titleSelection: '{topic}',
+    labels: ['defect', ...labels],
+    body: replaceVariablesInBody(defectTemplate, query)
+  };
+}
+
+function getSubIssue({ topic, ...query }) {
+  return {
+    ...getGithubQuery(query),
+    title: topic ? `[${topic}] {title}` : title,
+    titleSelection: topic ? '{title}' : '{topic}',
+    body: replaceVariablesInBody(subIssueTemplate, query)
+  };
+}
+
+export default (query) => {
+  prettifierLog(`Serving templates`);
+  const templates = {
+    bug: addComputedQuery(getBug(query)),
+    defect: addComputedQuery(getDefect(query)),
+    feature: addComputedQuery(getFeature(query)),
+    subIssue: addComputedQuery(getSubIssue(query)),
+    standard: addComputedQuery(getStandard(query))
+  };
+
+  const allTemplates = !templates[query.t];
+  return allTemplates ? templates : { [query.t]: templates[query.t] };
+};

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -41,7 +41,7 @@ function getBug({ labels = [], ...query }) {
     ...getGithubQuery(query),
     title,
     titleSelection: '{topic}',
-    labels: ['bug', ...labels],
+    labels: ['bug', ...[].concat(labels)],
     body: replaceVariablesInBody(bugTemplate, query)
   };
 }
@@ -60,7 +60,7 @@ function getDefect({ labels = [], ...query }) {
     ...getGithubQuery(query),
     title,
     titleSelection: '{topic}',
-    labels: ['defect', ...labels],
+    labels: ['defect', ...[].concat(labels)],
     body: replaceVariablesInBody(defectTemplate, query)
   };
 }

--- a/templates/bug.md
+++ b/templates/bug.md
@@ -1,0 +1,11 @@
+## description
+{describe the buggy behavior}
+
+## how to reproduce
+- {optional: describe steps to reproduce bug}
+
+## specs
+{optional: describe a possible fix for this bug, if not obvious}
+
+## misc
+{optional: other useful info}

--- a/templates/defect.md
+++ b/templates/defect.md
@@ -1,0 +1,11 @@
+## description
+{describe the defective behavior}
+
+## how to reproduce
+- {optional: describe steps to reproduce defect}
+
+## specs
+{optional: describe a possible fix for this defect, if not obvious}
+
+## misc
+{optional: other useful info}

--- a/templates/feature.md
+++ b/templates/feature.md
@@ -1,0 +1,8 @@
+## requirements
+{describe the new feature}
+
+## specs
+{optional: describe technical specs to implement this feature, if not obvious}
+
+## misc
+{optional: other useful info}

--- a/templates/sub-issue.md
+++ b/templates/sub-issue.md
@@ -1,7 +1,10 @@
-← #$parentIssueNo
+← #$parentIssueNumber
 
 ## requirements
-{requirements}
+{describe the new feature}
 
 ## specs
-{specs}
+{optional: describe technical specs to implement this feature, if not obvious}
+
+## misc
+{optional: other useful info}

--- a/templates/sub-issue.md
+++ b/templates/sub-issue.md
@@ -1,0 +1,7 @@
+← #$parentIssueNo
+
+## requirements
+{requirements}
+
+## specs
+{specs}


### PR DESCRIPTION
Issue #64

**test plan**
tested with `ngrok`:
- http://f4e96aa9.ngrok.io/templates
  - returns every template
  - `computedQuery` is correct
- http://f4e96aa9.ngrok.io/templates?t=bug
  - return only bug (I tested it with every template: bug, defect, standard, feature, subIssue)
- http://f4e96aa9.ngrok.io/templates?labels=ciao&labels=ciao2
  - correctly adds labels `ciao`, `ciao2` to every template
- http://f4e96aa9.ngrok.io/templates?t=subIssue&parentIssueNumber=321
  - correctly replaces variable `parentIssueNumber` with `321`