### PR TITLE
#74: [macro] add feature to split macro issues (closes #74)

### DIFF
--- a/config-ci.json
+++ b/config-ci.json
@@ -16,6 +16,7 @@
   },
   "platforms": [
     "github",
-    "hophop"
+    "hophop",
+    "extension"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-prettifier",
+  "name": "nemobot",
   "version": "0.1.0",
   "description": "github api based tool that enforces style conventions in the issue tracker",
   "main": "lib/index.js",
@@ -10,36 +10,39 @@
     "clean": "rm -rf lib && mkdir lib",
     "build": "npm run clean && babel src --out-dir lib && cp config.json lib",
     "watch": "npm run clean && cp config.json lib && babel src --out-dir lib --watch",
-    "start": "DEBUG=* node lib/index.js"
+    "start": "DEBUG=prettifier*,http,express:* node lib/index.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/buildo/github-prettifier.git"
+    "url": "git+https://github.com/buildo/nemobot.git"
   },
   "author": "buildo",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/buildo/github-prettifier/issues"
+    "url": "https://github.com/buildo/nemobot/issues"
   },
-  "homepage": "https://github.com/buildo/github-prettifier#readme",
+  "homepage": "https://github.com/buildo/nemobot#readme",
   "dependencies": {
+    "babel-eslint": "^6.0.3",
     "body-parser": "^1.15.0",
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "lodash": "^4.5.0",
     "marked-ast": "^0.3.0",
     "marked-to-md": "^1.0.1",
-    "octokat": "^0.4.16",
+    "octokat": "^0.4.17",
     "request-promise": "^2.0.0",
     "rx": "^4.0.7",
     "tcomb": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
-    "babel-plugin-lodash": "2.1.0",
+    "babel-core": "^6.4.5",
+    "babel-polyfill": "^6.4.5",
+    "babel-plugin-lodash": "2.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^2.1.0",
+    "eslint": "^2.9.0",
     "eslint-config-buildo": "github:buildo/eslint-config-buildo"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,19 @@
+import 'babel-core/register';
+import 'babel-polyfill';
 import express from 'express';
 import bodyParser from 'body-parser';
 import Rx from 'rx';
 import { find } from 'lodash';
 import processors from './processors';
 import getTemplates from './templates';
-import { isEvent } from './validators';
+import { isEvent, isExtensionEvent } from './validators';
 import config from './config';
 
 const platforms = config.platforms.map(p => `x-${p}-event`);
 const subject = new Rx.Subject();
 
 const onNext = (event, delay) => {
-  if (isEvent(event)) {
+  if (isEvent(event) || isExtensionEvent(event)) {
     setTimeout(() => subject.onNext(event), delay);
   }
 };

--- a/src/md-renderer.js
+++ b/src/md-renderer.js
@@ -1,6 +1,6 @@
 import marked from 'marked-ast';
 import MdRenderer from 'marked-to-md';
-import { includes } from 'lodash';
+import { includes, find } from 'lodash';
 
 
 function transform(ast, visitors) {
@@ -26,6 +26,19 @@ function transform(ast, visitors) {
   });
 
   return { transformedAst, transformed };
+}
+
+export function getSubIssuesList(input) {
+  const ast = marked.parse(input);
+  let currentSection;
+
+  return find(ast, node => {
+    // keep track of the current section
+    if (node.type === 'heading') {
+      currentSection = node;
+    }
+    return currentSection && includes(currentSection.text[0], 'sub-issues') && node.type === 'list';
+  });
 }
 
 export default (input, visitors) => {

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -3,5 +3,6 @@ export default [
   require('./subIssues').default,
   require('./gifs').default,
   require('./reminders').default,
-  require('./state').default
+  require('./state').default,
+  require('./splitMacroIssue').default
 ];

--- a/src/processors/splitMacroIssue.js
+++ b/src/processors/splitMacroIssue.js
@@ -105,18 +105,15 @@ async function splitMacroIssue(repoName, macroIssueNumber) {
   const subIssues = await getSubIssues(repoName, originalMacroIssue);
   const openSubIssues = filter(subIssues, { state: 'open' });
   const closedSubIssues = filter(subIssues, { state: 'closed' });
-  console.log('0');
+
   // remove sub-issues paragraph in originalMacroIssue to avoid conflicts
   await removeSubIssuePragraph(repoName, originalMacroIssue);
-  console.log('1');
+
   const { openMacroIssue, closedMacroIssue } = await createOpenAndClosedMacroIssues(repoName, macroIssueNumber);
-  console.log('2');
   // openMacroIssue
   await populateNewMacroIssue(repoName, macroIssueNumber, openMacroIssue.number, openSubIssues);
-  console.log('3');
   // closedMacroIssue
   await populateNewMacroIssue(repoName, macroIssueNumber, closedMacroIssue.number, closedSubIssues);
-  console.log('4');
 }
 
 export default ({ subject }) => {

--- a/src/processors/splitMacroIssue.js
+++ b/src/processors/splitMacroIssue.js
@@ -1,0 +1,129 @@
+import { find, startsWith, filter } from 'lodash';
+import { subIssueValidArrows, isSplitMacroIssueEvent } from '../validators';
+import { prettifierLog, configForRepo } from '../utils';
+import mdRenderer, { getSubIssuesList } from '../md-renderer';
+import {
+  updateIssueBody,
+  getNewBodyWithUpdatedSubIssues
+} from '../processors/subIssues';
+
+function getIssue(repoName, issueNumber) {
+  const { github, org, name } = configForRepo(repoName);
+  return github.repos(org, name).issues(issueNumber).fetch();
+}
+
+function getSubIssues(repoName, macroIssue) {
+  const subIssuesList = getSubIssuesList(macroIssue.body);
+  return Promise.all(subIssuesList.body.map(listItem => {
+    const regExp = /#(\d+)/;
+    const text = find(listItem.text, x => (x.text || x).match(regExp));
+    const [, subIssueNumber] = text.match(regExp) || [];
+    return getIssue(repoName, subIssueNumber);
+  }));
+}
+
+function createNewIssue(repoName, issue) {
+  const { github, org, name } = configForRepo(repoName);
+
+  const _issue = {
+    ...issue,
+    assignee: issue.assignee ? issue.assignee.login : null,
+    milestone: issue.milestone ? issue.milestone.number : null,
+    labels: issue.labels ? issue.labels.map(l => l.name).filter(l => l !== 'customers') : null
+  };
+  return github.repos(org, name).issues.create(_issue);
+}
+
+function removeSubIssuePragraph(repoName, macroIssue) {
+  const visitors = {
+    onSubissues: () => [] // remove sub-issues
+  };
+
+  const newBody = mdRenderer(macroIssue.body, visitors).replace('## sub-issues', '');
+  return updateIssueBody(repoName, newBody, macroIssue);
+}
+
+function upsertSubIssueToMacro(repoName, macroIssue, subIssue) {
+  const newBody = getNewBodyWithUpdatedSubIssues(macroIssue, subIssue);
+  return updateIssueBody(repoName, newBody, macroIssue);
+}
+
+function upsertSubIssuesToMacro(repoName, macroIssue, subIssues) {
+  const newBody = subIssues.reduce(
+    (body, subIssue) => getNewBodyWithUpdatedSubIssues({ body }, subIssue),
+    macroIssue.body
+  );
+  return updateIssueBody(repoName, newBody, macroIssue);
+}
+
+function getNewBodyWithUpdatedParent(subIssue, macroIssue) {
+  const usedArrow = find(subIssueValidArrows, arrow => startsWith(subIssue.body, `${arrow} #`));
+
+  if (usedArrow) {
+    const regExp = new RegExp(`${usedArrow} #\\d+`);
+    return subIssue.body.replace(regExp, `${usedArrow} #${macroIssue.number}`);
+  } else {
+    return `${subIssueValidArrows[0]} #${macroIssue.number}\n\n${subIssue.body}`;
+  }
+}
+
+function upsertParentToSubIssue(repoName, subIssue, macroIssue) {
+  const newBody = getNewBodyWithUpdatedParent(subIssue, macroIssue);
+  return updateIssueBody(repoName, newBody, subIssue);
+}
+
+function upsertParentToSubIssues(repoName, subIssues, macroIssue) {
+  return Promise.all(subIssues.map(subIssue => upsertParentToSubIssue(repoName, subIssue, macroIssue)));
+}
+
+async function populateNewMacroIssue(repoName, originalMacroIssueNumber, newMacroIssueNumber, subIssues) {
+  const originalMacroIssue = await getIssue(repoName, originalMacroIssueNumber);
+  const newMacroIssue = await getIssue(repoName, newMacroIssueNumber);
+  await upsertSubIssueToMacro(repoName, originalMacroIssue, newMacroIssue);
+  await upsertParentToSubIssue(repoName, newMacroIssue, originalMacroIssue);
+
+  const updatedNewMacroIssue = await getIssue(repoName, newMacroIssueNumber);
+
+  await upsertSubIssuesToMacro(repoName, updatedNewMacroIssue, subIssues);
+  await upsertParentToSubIssues(repoName, subIssues, updatedNewMacroIssue);
+}
+
+async function createOpenAndClosedMacroIssues(repoName, originalMacroIssueNumber) {
+  const originalMacroIssue = await getIssue(repoName, originalMacroIssueNumber);
+  const openMacroIssue = await createNewIssue(repoName, originalMacroIssue);
+  const closedMacroIssue = await createNewIssue(repoName, originalMacroIssue);
+
+  const { github, org, name } = configForRepo(repoName);
+  await github.repos(org, name).issues(closedMacroIssue.number).update({ state: 'closed' });
+
+  return { openMacroIssue, closedMacroIssue };
+}
+
+async function splitMacroIssue(repoName, macroIssueNumber) {
+  const originalMacroIssue = await getIssue(repoName, macroIssueNumber);
+
+  const subIssues = await getSubIssues(repoName, originalMacroIssue);
+  const openSubIssues = filter(subIssues, { state: 'open' });
+  const closedSubIssues = filter(subIssues, { state: 'closed' });
+  console.log('0');
+  // remove sub-issues paragraph in originalMacroIssue to avoid conflicts
+  await removeSubIssuePragraph(repoName, originalMacroIssue);
+  console.log('1');
+  const { openMacroIssue, closedMacroIssue } = await createOpenAndClosedMacroIssues(repoName, macroIssueNumber);
+  console.log('2');
+  // openMacroIssue
+  await populateNewMacroIssue(repoName, macroIssueNumber, openMacroIssue.number, openSubIssues);
+  console.log('3');
+  // closedMacroIssue
+  await populateNewMacroIssue(repoName, macroIssueNumber, closedMacroIssue.number, closedSubIssues);
+  console.log('4');
+}
+
+export default ({ subject }) => {
+  subject
+    .filter(isSplitMacroIssueEvent)
+    .subscribe(({ body: { macroIssueNumber, repoName } }) => {
+      prettifierLog(`Splitting macro issue #${macroIssueNumber} in repo ${repoName}`);
+      splitMacroIssue(repoName, macroIssueNumber);
+    });
+};

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -13,7 +13,7 @@ const title = '[{topic}] {title}';
 
 
 function addComputedQuery(templateObj) {
-  const { labels = [], ..._others} = templateObj;
+  const { labels = [], ..._others } = templateObj;
   const others = omitBy(_others, x => !x);
 
   return {
@@ -82,7 +82,7 @@ function getPR(query) {
 }
 
 export default (query) => {
-  prettifierLog(`Serving templates`);
+  prettifierLog('Serving templates');
   const templates = {
     bug: addComputedQuery(getBug(query)),
     defect: addComputedQuery(getDefect(query)),

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import Octokat from 'octokat';
 import debug from 'debug';
 import { find } from 'lodash';
-import config from './config.json';
+import config from './config.js';
 
 
 export const prettifierLog = debug('prettifier');

--- a/src/validators.js
+++ b/src/validators.js
@@ -5,7 +5,7 @@ export const subIssueValidArrows = ['←', '&larr;', '&#8592;', '&#x2190;'];
 
 const isStruct = (StructType, x) => {
   try {
-    StructType({...x});
+    StructType({ ...x });
     return true;
   } catch (e) {
     return false;
@@ -83,6 +83,19 @@ const HophopEvent = t.struct({
   })
 });
 
+const ExtensionEvent = t.struct({
+  event: t.refinement(t.String, s => startsWith(s, 'extension-')),
+  body: t.Object
+});
+
+const SplitMacroIssueEvent = t.struct({
+  event: t.enums.of(['extension-split-macro-issue']),
+  body: t.struct({
+    macroIssueNumber: t.Number,
+    repoName: t.String
+  })
+});
+
 export const isEvent = x => isStruct(Event, x);
 export const isPullRequestEvent = x => isStruct(PullRequestEvent, x);
 export const isIssueEvent = x => isStruct(IssueEvent, x);
@@ -92,3 +105,5 @@ export const isReminderEvent = x => isStruct(ReminderEvent, x);
 export const isTopicReminderEvent = x => isStruct(TopicReminderEvent, x);
 export const isTestPlanReminderEvent = x => isStruct(TestPlanReminderEvent, x);
 export const isHophopEvent = x => isStruct(HophopEvent, x);
+export const isExtensionEvent = x => isStruct(ExtensionEvent, x);
+export const isSplitMacroIssueEvent = x => isStruct(SplitMacroIssueEvent, x);


### PR DESCRIPTION
Issue #74

## Test Plan

### tests performed
- tested on fake macro issues on this repo (many of them :D)
  - creates 2 new macro issues (one open and one closed)
  - moves sub-issues to new macro
  - set 2 new macro as sub-issues of original macro

- tested on https://github.omnilab.our.buildo.io/buildo/aliniq/issues/2527 (which had `labels`, `milestone` and `assignee`!)
  - created https://github.omnilab.our.buildo.io/buildo/aliniq/issues/2635 (closed from the beginning)
  - created https://github.omnilab.our.buildo.io/buildo/aliniq/issues/2634 (closed later on during the milestone)
  - labels, milestones and assignee correctly passed two 2634/5
    - they also had label `customers`: I fixed it later here https://github.com/buildo/nemobot/pull/85/commits/610205d74d0e41b00a263bead20ae9c25ccc24ae#diff-bc4877ead44bab2b0551a458e6eae035R32

### tests not performed (domain coverage)
- I didn't test that `customers` label is actually filtered out, but I'm pretty confident :)
(https://github.com/buildo/nemobot/pull/85/commits/610205d74d0e41b00a263bead20ae9c25ccc24ae#diff-bc4877ead44bab2b0551a458e6eae035R32)
