### PR TITLE
#88: [branch-preview] move "preview branch" logic to nemobot (closes #88)

### DIFF
--- a/config-ci.json
+++ b/config-ci.json
@@ -17,6 +17,7 @@
   "platforms": [
     "github",
     "hophop",
-    "extension"
+    "extension",
+    "drone"
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,22 @@ import 'babel-polyfill';
 import express from 'express';
 import bodyParser from 'body-parser';
 import Rx from 'rx';
-import { find } from 'lodash';
+import { find, some, upperFirst } from 'lodash';
 import processors from './processors';
 import getTemplates from './templates';
-import { isEvent, isExtensionEvent } from './validators';
+import * as validators from './validators';
 import config from './config';
 
 const platforms = config.platforms.map(p => `x-${p}-event`);
 const subject = new Rx.Subject();
 
+const isEvent = (x) => {
+  const majorValidators = config.platforms.map(p => `is${upperFirst(p)}Event`);
+  return some(majorValidators, v => validators[v](x));
+};
+
 const onNext = (event, delay) => {
-  if (isEvent(event) || isExtensionEvent(event)) {
+  if (isEvent(event)) {
     setTimeout(() => subject.onNext(event), delay);
   }
 };

--- a/src/processors/branchPreview.js
+++ b/src/processors/branchPreview.js
@@ -13,13 +13,13 @@ async function addBranchPreviewComment(repoName, pullRequestNumber, previewURL) 
   if (!alreadyHasBranchPreviewComment) {
     prettifierLog(`Adding branch-preview comment to pull request #${pullRequestNumber} in repo ${repoName}`);
 
-    const LINK = `### 🐥 [preview this branch](${previewURL}`;
-    const IE_LINK = `### 💩 [preview this branch on IE](https://www.browserling.com/browse/win/7/ie/11/${previewURL}`;
+    const LINK = `### 🐥 [preview this branch](${previewURL})`;
+    const IE_LINK = `### 💩 [preview this branch on IE](https://www.browserling.com/browse/win/7/ie/11/${previewURL})`;
     const CORS_REMINDER = '(remember to [disable CORS](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi))';
     const API_REMINDER = '*N.B. this runs against the __master__ version of the API*';
 
     github.repos(org, name).issues(pullRequestNumber).comments.create({
-      body: `${MARKER}${[LINK, IE_LINK, CORS_REMINDER, API_REMINDER].join('\n')}`
+      body: `${[MARKER, LINK, IE_LINK, CORS_REMINDER, API_REMINDER].join('\n')}`
     });
   }
 }

--- a/src/processors/branchPreview.js
+++ b/src/processors/branchPreview.js
@@ -1,0 +1,33 @@
+import { includes } from 'lodash';
+import { configForRepo, prettifierLog } from '../utils';
+import { isBranchPreviewEvent } from '../validators';
+
+const MARKER = '<!-- SANDCASTLE_COMMENT -->';
+
+async function addBranchPreviewComment(repoName, pullRequestNumber, previewURL) {
+  const { github, org, name } = configForRepo(repoName);
+
+  const comments = await github.repos(org, name).issues(pullRequestNumber).comments.fetch();
+  const alreadyHasBranchPreviewComment = includes(comments.map(c => c.body), MARKER);
+
+  if (!alreadyHasBranchPreviewComment) {
+    prettifierLog(`Adding branch-preview comment to pull request #${pullRequestNumber} in repo ${repoName}`);
+
+    const LINK = `### 🐥 [preview this branch](${previewURL}`;
+    const IE_LINK = `### 💩 [preview this branch on IE](https://www.browserling.com/browse/win/7/ie/11/${previewURL}`;
+    const CORS_REMINDER = '(remember to [disable CORS](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi))';
+    const API_REMINDER = '*N.B. this runs against the __master__ version of the API*';
+
+    github.repos(org, name).issues(pullRequestNumber).comments.create({
+      body: `${MARKER}${[LINK, IE_LINK, CORS_REMINDER, API_REMINDER].join('\n')}`
+    });
+  }
+}
+
+export default ({ subject }) => {
+  subject
+    .filter(isBranchPreviewEvent)
+    .subscribe(({ body: { pullRequestNumber, repoName, previewURL } }) => {
+      addBranchPreviewComment(repoName, pullRequestNumber, previewURL);
+    });
+};

--- a/src/processors/branchPreview.js
+++ b/src/processors/branchPreview.js
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import { find, includes } from 'lodash';
 import { configForRepo, prettifierLog } from '../utils';
 import { isBranchPreviewEvent } from '../validators';
 
@@ -8,7 +8,7 @@ async function addBranchPreviewComment(repoName, pullRequestNumber, previewURL) 
   const { github, org, name } = configForRepo(repoName);
 
   const comments = await github.repos(org, name).issues(pullRequestNumber).comments.fetch();
-  const alreadyHasBranchPreviewComment = includes(comments.map(c => c.body), MARKER);
+  const alreadyHasBranchPreviewComment = !!find(comments.map(c => c.body), c => includes(c, MARKER));
 
   if (!alreadyHasBranchPreviewComment) {
     prettifierLog(`Adding branch-preview comment to pull request #${pullRequestNumber} in repo ${repoName}`);

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -4,5 +4,6 @@ export default [
   require('./gifs').default,
   require('./reminders').default,
   require('./state').default,
-  require('./splitMacroIssue').default
+  require('./splitMacroIssue').default,
+  require('./branchPreview').default
 ];

--- a/src/validators.js
+++ b/src/validators.js
@@ -26,7 +26,7 @@ const MacroIssue = t.struct({
   repository: t.Object
 });
 
-const Event = t.struct({
+const GithubEvent = t.struct({
   event: t.String,
   body: t.struct({
     issue: t.maybe(t.Object),
@@ -110,7 +110,7 @@ const BranchPreviewEvent = t.struct({
   })
 });
 
-export const isEvent = x => isStruct(Event, x);
+export const isGithubEvent = x => isStruct(GithubEvent, x);
 export const isPullRequestEvent = x => isStruct(PullRequestEvent, x);
 export const isIssueEvent = x => isStruct(IssueEvent, x);
 export const isSubIssueEvent = x => isStruct(SubIssueEvent, x);

--- a/src/validators.js
+++ b/src/validators.js
@@ -96,6 +96,20 @@ const SplitMacroIssueEvent = t.struct({
   })
 });
 
+const DroneEvent = t.struct({
+  event: t.refinement(t.String, s => startsWith(s, 'drone-')),
+  body: t.Object
+});
+
+const BranchPreviewEvent = t.struct({
+  event: t.enums.of(['drone-branch-preview']),
+  body: t.struct({
+    pullRequestNumber: t.Number,
+    repoName: t.String,
+    previewURL: t.String
+  })
+});
+
 export const isEvent = x => isStruct(Event, x);
 export const isPullRequestEvent = x => isStruct(PullRequestEvent, x);
 export const isIssueEvent = x => isStruct(IssueEvent, x);
@@ -107,3 +121,5 @@ export const isTestPlanReminderEvent = x => isStruct(TestPlanReminderEvent, x);
 export const isHophopEvent = x => isStruct(HophopEvent, x);
 export const isExtensionEvent = x => isStruct(ExtensionEvent, x);
 export const isSplitMacroIssueEvent = x => isStruct(SplitMacroIssueEvent, x);
+export const isDroneEvent = x => isStruct(DroneEvent, x);
+export const isBranchPreviewEvent = x => isStruct(BranchPreviewEvent, x);


### PR DESCRIPTION
Issue #88

## Test Plan

### tests performed
tested on this PR:
- send this `curl`:
```sh
curl -H "x-drone-event: drone-branch-preview" -H "Content-Type: application/json" -X POST -d '{"pullRequestNumber":90,"repoName":"nemobot", "previewURL": "http://google.it"}' http://16cf9587.ngrok.io
```
- preview comment appears
  - IE link correctly points to "google.it" on browserling
- resend same `curl`
  - nothing happens because comment already exists --> 👍 

### tests not performed (domain coverage)
